### PR TITLE
fix: string type side effects

### DIFF
--- a/src/description.rs
+++ b/src/description.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 #[derive(Clone, Debug)]
 pub enum SideEffects {
     Bool(bool),
+    String(String),
     Array(Vec<String>),
 }
 
@@ -85,27 +86,19 @@ impl PkgJSON {
             // TODO: should optimized
             if let Some(b) = value.as_bool() {
                 Some(SideEffects::Bool(b))
+            } else if let Some(s) = value.as_str() {
+                Some(SideEffects::String(s.to_owned()))
             } else if let Some(vec) = value.as_array() {
                 let mut ans = vec![];
                 for value in vec {
                     if let Some(str) = value.as_str() {
                         ans.push(str.to_string());
                     } else {
-                        println!(
-                            "Warning: sideEffects in {} had unexpected value {}",
-                            file_path.display(),
-                            value
-                        );
                         return None;
                     }
                 }
                 Some(SideEffects::Array(ans))
             } else {
-                println!(
-                    "warning: sideEffects in {} had unexpected value {}",
-                    file_path.display(),
-                    value
-                );
                 None
             }
         });

--- a/tests/cases.rs
+++ b/tests/cases.rs
@@ -2623,6 +2623,23 @@ fn load_side_effects_test() {
         Some(SideEffects::Bool(false))
     ));
 
+    let string_side_effects_path = if let ResolveResult::Info(info) =
+        resolver.resolve(&case_path, "string-side-effects").unwrap()
+    {
+        info.path
+    } else {
+        panic!("error")
+    };
+
+    assert!(matches!(
+        resolver
+            .load_side_effects(&string_side_effects_path)
+            .unwrap()
+            .unwrap()
+            .1,
+        Some(SideEffects::String(s)) if s == "*.js"
+    ));
+
     // match resolver
     //     .load_side_effects(&p(vec!["incorrect-package", "sideeffects-map"]))
     //     .unwrap_err()

--- a/tests/fixtures/exports-field/node_modules/string-side-effects/package.json
+++ b/tests/fixtures/exports-field/node_modules/string-side-effects/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "exports-field",
+  "version": "1.0.0",
+  "main": "./index.js",
+  "sideEffects": "*.js"
+}


### PR DESCRIPTION
- string type sideEffects, reference to [`SideEffectsFlagPlugin.moduleHasSideEffects`](https://github.com/webpack/webpack/blob/4b4ca3bb53f36a5b8fc6bc1bd976ed7af161bd80/lib/optimize/SideEffectsFlagPlugin.js#L322-L335)
- delete `println!` for invalid sideEffects field