### PR TITLE
perf: add symlink plugin

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ use log::*;
 pub use options::{AliasMap, EnforceExtension, Options};
 use plugin::{
     AliasPlugin, BrowserFieldPlugin, ImportsFieldPlugin, ParsePlugin, Plugin, PreferRelativePlugin,
+    SymlinkPlugin,
 };
 use rustc_hash::FxHasher;
 use state::State;
@@ -144,6 +145,10 @@ impl Resolver {
         } else {
             self._resolve(info, &mut context)
         };
+
+        let result =
+            result.map_success(|info| SymlinkPlugin::default().apply(self, info, &mut context));
+
         // let duration = start.elapsed().as_millis();
         // println!("time cost: {:?} us", duration); // us
         // if duration > 10 {
@@ -154,8 +159,9 @@ impl Resolver {
         //         request,
         //     );
         // }
+
         match result {
-            State::Success(result) => self.normalize_result(result),
+            State::Success(result) => Ok(result),
             State::Error(err) => Err(err),
             State::Resolving(_) | State::Failed(_) => Err(Error::ResolveFailedTag),
         }

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -1,11 +1,6 @@
-use crate::{Error, RResult, ResolveResult, Resolver};
-
 use path_absolutize::Absolutize;
 
-use std::{
-    borrow::Cow,
-    path::{Path, PathBuf},
-};
+use std::{borrow::Cow, path::Path};
 
 pub trait NormalizePath {
     fn normalize(&self) -> Cow<Path>;
@@ -16,28 +11,5 @@ impl NormalizePath for Path {
     fn normalize(&self) -> Cow<Path> {
         // perf: this method does not re-allocate memory if the path does not contain any dots.
         self.absolutize_from(Path::new("")).unwrap()
-    }
-}
-
-impl Resolver {
-    #[tracing::instrument]
-    fn normalize_path(&self, path: &Path) -> RResult<PathBuf> {
-        if self.options.symlinks {
-            let entry = self.load_entry(path)?;
-            entry.symlink().map_err(Error::Io)
-        } else {
-            Ok(path.normalize().to_path_buf())
-        }
-    }
-
-    pub(super) fn normalize_result(&self, result: ResolveResult) -> RResult<ResolveResult> {
-        match result {
-            ResolveResult::Info(info) => {
-                debug_assert!(info.request.target.is_empty());
-                let result = self.normalize_path(&info.path)?;
-                Ok(ResolveResult::Info(info.with_path(result)))
-            }
-            ResolveResult::Ignored => Ok(ResolveResult::Ignored),
-        }
     }
 }

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -6,6 +6,7 @@ mod main_field;
 mod main_file;
 mod parse;
 mod prefer_relative;
+mod symlink;
 
 use crate::{context::Context, Info, Resolver, State};
 
@@ -17,6 +18,7 @@ pub use main_field::MainFieldPlugin;
 pub use main_file::MainFilePlugin;
 pub use parse::ParsePlugin;
 pub use prefer_relative::PreferRelativePlugin;
+pub use symlink::SymlinkPlugin;
 
 pub(crate) trait Plugin {
     fn apply(&self, resolver: &Resolver, info: Info, context: &mut Context) -> State;

--- a/src/plugin/symlink.rs
+++ b/src/plugin/symlink.rs
@@ -1,0 +1,72 @@
+use super::Plugin;
+use crate::{
+    log::depth, normalize::NormalizePath, Context, Info, RResult, ResolveResult, Resolver, State,
+};
+
+#[derive(Default)]
+pub struct SymlinkPlugin;
+
+impl Plugin for SymlinkPlugin {
+    fn apply(&self, resolver: &Resolver, info: Info, context: &mut Context) -> State {
+        debug_assert!(info.request.target.is_empty());
+
+        if !resolver.options.symlinks {
+            let path = info.path.normalize();
+            let info = Info {
+                path: path.to_path_buf(),
+                request: info.request,
+            };
+            return State::Success(ResolveResult::Info(info));
+        }
+
+        tracing::debug!("SymlinkPlugin works({})", depth(&context.depth));
+        let state = self.resolve_symlink(resolver, info, context);
+        tracing::debug!("Leaving SymlinkPlugin({})", depth(&context.depth));
+        state
+    }
+}
+
+impl SymlinkPlugin {
+    fn resolve_symlink(&self, resolver: &Resolver, info: Info, _context: &mut Context) -> State {
+        let entry = match resolver.load_entry(&info.path) {
+            RResult::Ok(entry) => entry,
+            RResult::Err(error) => return State::Error(error),
+        };
+
+        let entry_path = entry.path.as_path();
+        let mut entry = entry.as_ref();
+        let mut index = 0;
+        let mut symlink = None;
+
+        loop {
+            if let Some(link) = entry.symlink() {
+                symlink = Some(link.to_path_buf());
+                break;
+            }
+            if let Some(e) = entry.parent.as_ref() {
+                index += 1;
+                entry = e;
+            } else {
+                break;
+            }
+        }
+
+        let path = if let Some(symlink) = symlink {
+            let mut path = symlink;
+            let tail = entry_path
+                .components()
+                .rev()
+                .take(index)
+                .collect::<Vec<_>>();
+            for c in tail.into_iter().rev() {
+                path.push(c);
+            }
+            path
+        } else {
+            info.path.normalize().to_path_buf()
+        };
+
+        let info = info.with_path(path);
+        State::Success(ResolveResult::Info(info))
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -18,6 +18,13 @@ impl State {
         }
     }
 
+    pub fn map_success<F: FnOnce(Info) -> State>(self, op: F) -> Self {
+        match self {
+            State::Success(ResolveResult::Info(info)) => op(info),
+            _ => self,
+        }
+    }
+
     pub fn is_finished(&self) -> bool {
         matches!(self, State::Success(_) | State::Error(_))
     }


### PR DESCRIPTION
relates to #115

This is the first iteration of porting symlink plugin from enhanced-resolve.

This PR greatly reduces the need to call `std::fs::canonicalize` on symlinked paths, and does not call `canonicalize` at all for non-symlinked paths.

Before and after:

<img width="1826" alt="image" src="https://user-images.githubusercontent.com/1430279/215675999-620e7d47-c680-4b12-a9b3-60d6b3e50071.png">

Note: to remove `std::fs::canonicalize` entirely, the algorithm need to cache and reconstruct paths from results of `std::fs::read_link`, it is a bit more envolved and I'll look into it in the near future.
