### PR TITLE
refactor: refactor Info, replace PathBuf with Box<path>, delay .to_path_buf only when necessary

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -153,8 +153,7 @@ impl Resolver {
             Ok(cached.clone())
         } else {
             let entry = Arc::new(self.load_entry_uncached(&key)?);
-            let key = key.to_path_buf().into_boxed_path();
-            self.entries.entry(key).or_insert(entry.clone());
+            self.entries.entry(key.into()).or_insert(entry.clone());
             Ok(entry)
         }
     }

--- a/src/info.rs
+++ b/src/info.rs
@@ -1,36 +1,75 @@
-use crate::parse::Request;
-use std::path::PathBuf;
+use crate::{normalize::NormalizePath, parse::Request};
+use std::{
+    borrow::Cow,
+    path::{Path, PathBuf},
+};
 
 #[derive(Debug, Clone)]
 pub struct Info {
-    pub path: PathBuf,
-    pub request: Request,
+    path: Box<Path>,
+    request: Request,
+}
+
+impl<P: AsRef<Path>> From<P> for Info {
+    fn from(path: P) -> Self {
+        Self {
+            path: path.as_ref().into(),
+            request: Request::default(),
+        }
+    }
 }
 
 impl Info {
     #[must_use]
-    pub fn from(path: PathBuf, request: Request) -> Self {
-        Self { path, request }
-    }
-
-    #[must_use]
-    pub fn get_path(&self) -> PathBuf {
-        if self.request.target().is_empty() || self.request.target() == "." {
-            self.path.clone()
-        } else {
-            self.path.join(self.request.target())
+    pub fn new<P: AsRef<Path>>(path: P, request: Request) -> Self {
+        Self {
+            path: path.as_ref().into(),
+            request,
         }
     }
 
     #[must_use]
-    pub fn with_path(self, path: PathBuf) -> Self {
-        Self { path, ..self }
+    pub fn with_path<P: AsRef<Path>>(self, path: P) -> Self {
+        Self {
+            path: path.as_ref().into(),
+            ..self
+        }
+    }
+
+    #[must_use]
+    pub fn with_request(self, request: Request) -> Self {
+        Self { request, ..self }
     }
 
     #[must_use]
     pub fn with_target(self, target: &str) -> Self {
         let request = self.request.with_target(target);
         Self { request, ..self }
+    }
+
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    #[must_use]
+    pub fn request(&self) -> &Request {
+        &self.request
+    }
+
+    #[must_use]
+    pub fn to_resolved_path(&self) -> Cow<'_, Path> {
+        if self.request.target().is_empty() || self.request.target() == "." {
+            Cow::Borrowed(&self.path)
+        } else {
+            Cow::Owned(self.path.join(self.request.target()))
+        }
+    }
+
+    #[must_use]
+    pub fn normalize(mut self) -> Self {
+        self.path = self.path.normalize().into();
+        self
     }
 
     #[must_use]

--- a/src/plugin/alias.rs
+++ b/src/plugin/alias.rs
@@ -6,7 +6,7 @@ pub struct AliasPlugin;
 
 impl Plugin for AliasPlugin {
     fn apply(&self, resolver: &Resolver, info: Info, context: &mut Context) -> State {
-        let inner_target = info.request.target();
+        let inner_target = info.request().target();
         for (from, to) in &resolver.options.alias {
             if inner_target == from || inner_target.starts_with(&format!("{from}/")) {
                 tracing::debug!(
@@ -20,9 +20,9 @@ impl Plugin for AliasPlugin {
                             continue;
                         }
                         let normalized_target = inner_target.replacen(from, to, 1);
-                        let alias_info = Info::from(
-                            info.path.clone(),
-                            info.request.clone().with_target(&normalized_target),
+                        let alias_info = Info::new(
+                            info.path(),
+                            info.request().clone().with_target(&normalized_target),
                         );
                         let state = resolver._resolve(alias_info, context);
                         if state.is_finished() {

--- a/src/plugin/browser_field.rs
+++ b/src/plugin/browser_field.rs
@@ -14,7 +14,7 @@ impl<'a> BrowserFieldPlugin<'a> {
     }
 
     fn request_target_is_module_and_equal_alias_key(alias_key: &String, info: &Info) -> bool {
-        info.request.target().eq(alias_key)
+        info.request().target().eq(alias_key)
     }
 
     fn request_path_is_equal_alias_key_path(
@@ -22,7 +22,7 @@ impl<'a> BrowserFieldPlugin<'a> {
         info: &Info,
         extensions: &[String],
     ) -> bool {
-        let request_path = info.get_path();
+        let request_path = info.to_resolved_path();
         alias_path.eq(&request_path)
             || extensions.iter().any(|ext| {
                 let path_with_extension = Resolver::append_ext_for_path(&request_path, ext);
@@ -37,7 +37,7 @@ impl<'a> Plugin for BrowserFieldPlugin<'a> {
             return State::Resolving(info);
         }
         for (alias_key, alias_target) in &self.pkg_info.json.alias_fields {
-            let should_deal_alias = match matches!(info.request.kind(), PathKind::Normal) {
+            let should_deal_alias = match matches!(info.request().kind(), PathKind::Normal) {
                 true => Self::request_target_is_module_and_equal_alias_key(alias_key, &info),
                 false => Self::request_path_is_equal_alias_key_path(
                     &self.pkg_info.dir_path.join(alias_key),
@@ -66,9 +66,9 @@ impl<'a> Plugin for BrowserFieldPlugin<'a> {
                         // }
                         return State::Resolving(info);
                     }
-                    let alias_info = Info::from(
-                        self.pkg_info.dir_path.clone(),
-                        info.request.clone().with_target(converted),
+                    let alias_info = Info::new(
+                        &self.pkg_info.dir_path,
+                        info.request().clone().with_target(converted),
                     );
                     let state = resolver._resolve(alias_info, context);
                     if state.is_finished() {

--- a/src/plugin/exports_field.rs
+++ b/src/plugin/exports_field.rs
@@ -22,17 +22,17 @@ impl<'a> ExportsFieldPlugin<'a> {
 impl<'a> Plugin for ExportsFieldPlugin<'a> {
     fn apply(&self, resolver: &Resolver, info: Info, context: &mut Context) -> State {
         // info.path should end with `node_modules`.
-        let target = &info.request.target();
+        let target = info.request().target();
 
         let list = if let Some(root) = &self.pkg_info.json.exports_field_tree {
-            let query = info.request.query();
-            let fragment = info.request.fragment();
+            let query = info.request().query();
+            let fragment = info.request().fragment();
             let request_path = get_path_from_request(target);
 
             let target = match request_path {
                 Some(target) => format!(".{target}"),
                 None => {
-                    let path = info.path.join(&**target);
+                    let path = info.path().join(target);
                     let is_exist = match resolver.load_entry(&path) {
                         Ok(entry) => entry.is_exist(),
                         Err(err) => return State::Error(err),
@@ -81,13 +81,13 @@ impl<'a> Plugin for ExportsFieldPlugin<'a> {
                     "{}/package.json",
                     self.pkg_info.dir_path.display()
                 )),
-                color::blue(target),
+                color::blue(&target),
                 color::blue(&item),
                 depth(&context.depth)
             );
             let request = Resolver::parse(&item);
-            let info = Info::from(self.pkg_info.dir_path.clone(), request);
-            if !ExportsField::check_target(info.request.target()) {
+            let info = Info::new(self.pkg_info.dir_path.clone(), request);
+            if !ExportsField::check_target(info.request().target()) {
                 continue;
             }
             let state = resolver._resolve(info, context);

--- a/src/plugin/main_field.rs
+++ b/src/plugin/main_field.rs
@@ -1,6 +1,7 @@
 use super::Plugin;
 use crate::{
-    description::PkgInfo, log::color, log::depth, Context, Info, NormalizePath, Resolver, State,
+    description::PkgInfo, log::color, log::depth, normalize::NormalizePath, Context, Info,
+    Resolver, State,
 };
 
 pub struct MainFieldPlugin<'a> {
@@ -15,12 +16,12 @@ impl<'a> MainFieldPlugin<'a> {
 
 impl<'a> Plugin for MainFieldPlugin<'a> {
     fn apply(&self, resolver: &Resolver, info: Info, context: &mut Context) -> State {
-        let path = info.path.normalize();
+        let path = info.path().normalize();
         if !path.eq(&self.pkg_info.dir_path) {
             return State::Resolving(info);
         }
 
-        let main_field_info = Info::from(path.to_path_buf(), info.request.clone());
+        let main_field_info = Info::new(&path, info.request().clone());
 
         for user_main_field in &resolver.options.main_fields {
             if let Some(main_field) = self

--- a/src/plugin/main_file.rs
+++ b/src/plugin/main_file.rs
@@ -5,16 +5,13 @@ pub struct MainFilePlugin;
 
 impl Plugin for MainFilePlugin {
     fn apply(&self, resolver: &Resolver, info: Info, context: &mut Context) -> State {
-        let main_file_info = Info::from(info.path.clone(), info.request.clone());
         for main_file in &resolver.options.main_files {
             tracing::debug!(
                 "MainFile works, it pointed to {}({})",
                 color::blue(main_file),
                 depth(&context.depth)
             );
-            let main_file_info = main_file_info
-                .clone()
-                .with_target(&format!("./{main_file}"));
+            let main_file_info = info.clone().with_target(&format!("./{main_file}"));
             let state = resolver._resolve(main_file_info, context);
             if state.is_finished() {
                 return state;

--- a/src/plugin/parse.rs
+++ b/src/plugin/parse.rs
@@ -1,15 +1,15 @@
 use super::Plugin;
-use crate::{depth, parse::Request, Context, Info, Resolver, State};
+use crate::{depth, Context, Info, Resolver, State};
 
 #[derive(Default)]
 pub struct ParsePlugin;
 
 impl Plugin for ParsePlugin {
     fn apply(&self, resolver: &Resolver, info: Info, context: &mut Context) -> State {
-        let request = &info.request;
+        let request = info.request();
         let had_hash = !request.fragment().is_empty();
         let no_query = request.query().is_empty();
-        let had_request = !info.request.target().is_empty();
+        let had_request = !info.request().target().is_empty();
         if no_query && had_hash && had_request {
             tracing::debug!("ParsePlugin works({})", depth(&context.depth));
             let target = format!(
@@ -18,9 +18,7 @@ impl Plugin for ParsePlugin {
                 if request.is_directory() { "/" } else { "" },
                 request.fragment()
             );
-            let request = Request::default().with_target(&target);
-            let path = info.path.clone();
-            let info = Info::from(path, request);
+            let info = Info::from(info.path()).with_target(&target);
             let state = resolver._resolve(info, context);
             if state.is_finished() {
                 return state;

--- a/src/plugin/prefer_relative.rs
+++ b/src/plugin/prefer_relative.rs
@@ -6,14 +6,17 @@ pub struct PreferRelativePlugin;
 
 impl Plugin for PreferRelativePlugin {
     fn apply(&self, resolver: &Resolver, info: Info, context: &mut Context) -> State {
-        if info.request.target().starts_with("../") || info.request.target().starts_with("./") {
+        if info.request().target().starts_with("../") || info.request().target().starts_with("./") {
             return State::Resolving(info);
         }
 
         if resolver.options.prefer_relative {
             tracing::debug!("AliasPlugin works({})", depth(&context.depth));
-            let target = format!("./{}", info.request.target());
-            let info = Info::from(info.path.clone(), info.request.clone().with_target(&target));
+            let target = format!("./{}", info.request().target());
+            let info = Info::new(
+                info.path(),
+                info.request().clone().with_target(&target),
+            );
             let stats = resolver._resolve(info, context);
             if stats.is_finished() {
                 return stats;

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -85,12 +85,12 @@ impl Resolver {
             // `location` pointed to `dir/tsconfig.json`
             let dir = location.parent().unwrap().to_path_buf();
             let request = Self::parse(s);
-            let state = self._resolve(Info::from(dir, request), context);
+            let state = self._resolve(Info::new(dir, request), context);
             // Is it better to use cache?
             if let State::Success(result) = state {
                 let extends_tsconfig_json = match result {
                     ResolveResult::Info(info) => {
-                        self.parse_file_to_value(&info.get_path(), context)
+                        self.parse_file_to_value(&info.to_resolved_path(), context)
                     }
                     ResolveResult::Ignored => {
                         return Err(Error::UnexpectedValue(format!(

--- a/src/tsconfig_path.rs
+++ b/src/tsconfig_path.rs
@@ -98,10 +98,10 @@ impl Resolver {
             Resolver::create_match_list(location, &tsconfig.base_url, &tsconfig.paths);
 
         for entry in absolute_path_mappings {
-            let star_match = if entry.pattern == info.request.target() {
+            let star_match = if entry.pattern == info.request().target() {
                 ""
             } else {
-                match Self::match_star(&entry.pattern, info.request.target()) {
+                match Self::match_star(&entry.pattern, info.request().target()) {
                     Some(s) => s,
                     None => continue,
                 }
@@ -114,7 +114,7 @@ impl Resolver {
                     .replace('*', star_match);
 
                 let path = PathBuf::from(physical_path);
-                let result = self._resolve(Info::from(path, Request::default()), context);
+                let result = self._resolve(Info::new(path, Request::default()), context);
                 if result.is_finished() {
                     return result;
                 }

--- a/tests/cases.rs
+++ b/tests/cases.rs
@@ -2608,7 +2608,7 @@ fn load_side_effects_test() {
         .resolve(&case_path, "@scope/import-require")
         .unwrap()
     {
-        info.path
+        info.path().to_path_buf()
     } else {
         panic!("error")
     };
@@ -2639,7 +2639,7 @@ fn load_side_effects_test() {
 
     let exports_field_path =
         if let ResolveResult::Info(info) = resolver.resolve(&case_path, "exports-field").unwrap() {
-            info.path
+            info.path().to_path_buf()
         } else {
             panic!("error")
         };
@@ -2670,7 +2670,7 @@ fn load_side_effects_test() {
     let string_side_effects_path = if let ResolveResult::Info(info) =
         resolver.resolve(&case_path, "string-side-effects").unwrap()
     {
-        info.path
+        info.path().to_path_buf()
     } else {
         panic!("error")
     };


### PR DESCRIPTION
This PR greatly reduces PathBuf allocation by delaying calls to `to_path_buf`, using `Cow`, and using `Box<Path>`.