### PR TITLE
refactor: remove redundant string allocation from AliasPlugin

### DIFF
--- a/src/plugin/alias.rs
+++ b/src/plugin/alias.rs
@@ -17,7 +17,12 @@ impl<'a> Plugin for AliasPlugin<'a> {
     fn apply(&self, resolver: &Resolver, info: Info, context: &mut Context) -> State {
         let inner_target = info.request().target();
         for (from, to) in self.alias() {
-            if inner_target == from || inner_target.starts_with(&format!("{from}/")) {
+            if inner_target
+                .strip_prefix(from)
+                .into_iter()
+                .next()
+                .map_or(false, |c| c.is_empty() || c.starts_with('/'))
+            {
                 tracing::debug!(
                     "AliasPlugin works, triggered by '{from}'({})",
                     depth(&context.depth)


### PR DESCRIPTION
<img width="1338" alt="image" src="https://user-images.githubusercontent.com/1430279/219998042-017c6a3c-729a-4d2a-8840-0d2d933c1ef2.png">

This saves about 180ms in a large project and lots of short-lived memory allocations.